### PR TITLE
evolutility headless cms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.yaml
+start_docker.sh
 *.csv
 
 # Logs

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -53,6 +53,15 @@ module.exports = {
         },
       },
     },
+    {
+      // Source graphql des ressources textuelles ANDi publiques
+      resolve: "gatsby-source-graphql",
+      options: {
+        typeName: "query",
+        fieldName: "andi",
+        url: "https://andi.beta.gouv.fr/gql/",
+      },
+    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/misc/docker/evolutility/Dockerfile
+++ b/misc/docker/evolutility/Dockerfile
@@ -30,11 +30,13 @@ RUN npm install
 
 WORKDIR /src
 COPY ./start.sh /src/start.sh
+COPY ./run_graphql.sh /src/run_graphql.sh
 RUN chmod +x /src/start.sh
+RUN chmod +x /src/run_graphql.sh
 COPY ./server/config.js /src/server/config.js
 COPY ./server/*.js /src/server/models/
 COPY ./ui/*.js /src/ui/src/models/
 
 WORKDIR /src
-# ENTRYPOINT ["/bin/bash"]
-ENTRYPOINT ["/src/start.sh"]
+CMD ["/bin/bash"]
+#ENTRYPOINT ["/src/start.sh"]

--- a/misc/docker/public_graphql/Dockerfile
+++ b/misc/docker/public_graphql/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:10-alpine
+
+ARG PG_USER="user"
+ARG PG_PASS="secret"
+ARG PG_HOST="database"
+ARG PG_PORT="54320"
+ARG PG_DB="andi_entreprises"
+ENV DATABASE_URL=postgres://$PG_USER:$PG_PASS@$PG_HOST:$PG_PORT/$PG_DB
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+RUN mkdir /src
+WORKDIR /src
+
+
+RUN echo "Cloning evolutility source.." && \
+    git clone https://github.com/evoluteur/evolutility-server-node.git ./server
+
+WORKDIR /src/server
+RUN npm install
+
+
+WORKDIR /src
+COPY ./server/config.js /src/server/config.js
+COPY ./server/*.js /src/server/models/
+
+WORKDIR /src/server
+# ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["npm", "start"]

--- a/misc/docker/public_graphql/server/all_models.js
+++ b/misc/docker/public_graphql/server/all_models.js
@@ -1,0 +1,3 @@
+module.exports = {
+    asset: require('./asset_model'),
+};

--- a/misc/docker/public_graphql/server/asset_model.js
+++ b/misc/docker/public_graphql/server/asset_model.js
@@ -1,0 +1,39 @@
+module.exports = {
+    id: 'asset',
+    active: true,
+    table: 'asset',
+    pKey: 'id_internal',
+    title: 'Éléments de contenu',
+    titleField: 'id_internal',
+    searchFields: ['key', 'description', 'value'],
+    fields: [
+        {
+            id: 'id',
+            column: 'id_internal',
+            type: 'integer', 
+            label: 'identifiant',
+            readOnly: true
+        },
+        {
+            id: 'key',
+            column: 'key',
+            type: 'text', 
+            label: 'Clé',
+            inMany: true
+        },
+        {
+            id: 'description',
+            column: 'description',
+            type: 'text', 
+            label: 'Description',
+            inMany: true
+        },
+        {
+            id: 'value',
+            column: 'value',
+            type: 'textmultiline', 
+            label: 'Valeur',
+            inMany: true
+        }
+    ]
+}

--- a/misc/docker/public_graphql/server/config.js
+++ b/misc/docker/public_graphql/server/config.js
@@ -1,0 +1,41 @@
+// test ecrasement config
+module.exports = {
+
+	// Path to REST API
+	apiPath: '/api/v1/',
+	apiPort: process.env.PORT || 2000,
+
+	graphQL: true,
+	schemaQueries: true,
+
+	// DB connection
+	connectionString: process.env.DATABASE_URL || 'postgres://evol:love@localhost:5432/Evolutility', 
+	schema: 'public',
+
+	// OPTIONS
+	// Pagination and maximum number of rows
+	pageSize: 50,
+	lovSize: 100,
+	csvSize: 1000,
+	csvHeader: 'id', //label', // possible values: id, label
+
+	// - Timestamp columns u_date and c_date w/ date of record creation and last update 
+	wTimestamp: true,
+	// - "WhoIs" columns u_uid and c_uid w/ userid of creator and last modifier
+	wWhoIs: false,
+	// - Comments & Ratings (community feature) 
+	wComments: false,
+	wRating: false,
+    createdDateColumn: 'date_created',
+    updatedDateColumn: 'date_updated',
+
+	// - API discovery
+	apiInfo: true,
+
+	// Directory for uploaded files
+	uploadPath: '../evolutility-ui-react/public/pix/',
+
+	// Console log
+	consoleLog: true,
+
+};

--- a/misc/docker/public_graphql/server/user_model.js
+++ b/misc/docker/public_graphql/server/user_model.js
@@ -1,0 +1,46 @@
+module.exports = {
+    id: 'user',
+    active: true,
+    table: 'inscription',
+    pKey: 'id_internal',
+    title: 'Liste Inscriptions',
+    titleField: 'id_internal',
+    searchFields: ['nom', 'prenom', 'email'],
+    fields: [
+        {
+            id: 'id',
+            column: 'id_internal',
+            type: 'integer', 
+            label: 'identifiant',
+            readOnly: true
+        },
+        {
+            id: 'prenom',
+            column: 'prenom',
+            type: 'text', 
+            label: 'Prénom',
+            inMany: true
+        },
+        {
+            id: 'nom',
+            column: 'nom',
+            type: 'text', 
+            label: 'Nom',
+            inMany: true
+        },
+        {
+            id: 'email',
+            column: 'email',
+            type: 'text', 
+            label: 'e-mail',
+            inMany: true
+        },
+        {
+            id: 'date_inscription',
+            column: 'date_inscription',
+            type: 'datetime', 
+            label: 'Date d\'inscription',
+            inMany: true
+        },
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,6 +1559,14 @@
         "@xtuc/long": "4.2.1"
       }
     },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1722,6 +1730,80 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.1.tgz",
+      "integrity": "sha512-6Ghf+j3cQLCIvjXd2dJrLw+16HZbWbwmB1qlTc41BviB2hv+rK1nJr17Y9dWK0UD4p3i9Hfddx3tthpMKrueHg==",
+      "requires": {
+        "@types/node": "^9.4.6",
+        "apollo-utilities": "^1.0.0",
+        "zen-observable-ts": "^0.8.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "9.6.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.50.tgz",
+          "integrity": "sha512-9Yzqn2NzJxwFzon4W+aqUAMl3FiVnJ965f5F3H5T+EpUrHqb2Is1SPp/lsj2WFBqXrhIINJ5SzSwneLMg5PgSQ=="
+        }
+      }
+    },
+    "apollo-link-http": {
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.15.tgz",
+      "integrity": "sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
+          "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.19"
+          }
+        }
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz",
+      "integrity": "sha512-v6mRU1oN6XuX8beVIRB6OpF4q1ULhSnmy7ScnHnuo1qV6GaFmDcbdvXqxIkAV1Q8SQCo2lsv4HeqJOWhFfApOg==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
+          "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.19"
+          }
+        }
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "aproba": {
@@ -4473,6 +4555,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "des.js": {
       "version": "1.0.0",
@@ -7921,6 +8008,21 @@
         }
       }
     },
+    "gatsby-source-graphql": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-source-graphql/-/gatsby-source-graphql-2.1.3.tgz",
+      "integrity": "sha512-VYkopb5hxo/T1ZO3gWk4FxOQn7tMwO8u1ocQJ8U6HXV9/FV2fqkLpPViS5PN9W86MxbXXoJ3iSYIb0bzeRzx0g==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "apollo-link": "1.2.1",
+        "apollo-link-http": "^1.5.4",
+        "graphql": "^14.1.1",
+        "graphql-tools": "^3.0.4",
+        "invariant": "^2.2.4",
+        "node-fetch": "^1.7.3",
+        "uuid": "^3.1.0"
+      }
+    },
     "gatsby-telemetry": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.6.tgz",
@@ -8313,6 +8415,31 @@
       "integrity": "sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==",
       "requires": {
         "cross-fetch": "2.2.2"
+      }
+    },
+    "graphql-tools": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.1.1.tgz",
+      "integrity": "sha512-yHvPkweUB0+Q/GWH5wIG60bpt8CTwBklCSzQdEHmRUgAdEQKxw+9B7zB3dG7wB3Ym7M7lfrS4Ej+jtDZfA2UXg==",
+      "requires": {
+        "apollo-link": "^1.2.2",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
+          "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.19"
+          }
+        }
       }
     },
     "graphql-type-json": {
@@ -15107,6 +15234,14 @@
         "glob": "^7.1.2"
       }
     },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "ts-pnp": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.2.tgz",
@@ -16545,6 +16680,20 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
+      "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gatsby-plugin-react-helmet": "^3.1.2",
     "gatsby-plugin-sharp": "^2.2.7",
     "gatsby-source-filesystem": "^2.1.5",
+    "gatsby-source-graphql": "^2.1.3",
     "gatsby-transformer-sharp": "^2.2.3",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 import Layout from "../components/layout"
 // import Image from "../components/image"
@@ -8,92 +8,101 @@ import Layout from "../components/layout"
 /* TODO: 
  * - use gatsby images
  * - add SEO
- * /
+ */
+export const query = graphql`
+{ 
+    andi {
+        assets {
+            key
+            value
+        }
+    }
+}
+`
 
-/*
-const IndexPage = () => (
-  <Layout>
-    <SEO title="Home" />
-    <h1>Hi people</h1>
-    <p>Testing CI I C ?.</p>
-    <p>Now go build something great.</p>
-    <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-      <Image />
-    </div>
-    <Link to="/page-2/">Go to page 2</Link>
-  </Layout>
-)
-*/
 const abbr_andi = "accompagnement numérique au développement de l'insertion"
 
-const IndexPage = () => (
-    <Layout>
-     <div>
-        <section className="section section-grey">
-          <div className="row">
-            <div className="container text_1">
-              <h1>Essayez un métier simplement</h1>
-              <h2>Vous êtes en situation de handicap et vous souhaitez prendre ou reprendre contact avec la vie professionnelle ? Participez à notre expérience</h2>
-              <Link className="button large" to="/inscription">Je m'inscris</Link>
+class IndexPage extends React.Component {
+    constructor(props) {
+        super(props);
+        let data = {};
+        for (let asset of props.data.andi.assets) {
+            data[asset.key] = asset.value
+        }
+        this.d = data
+    }
+
+    render() {
+        return (
+        <Layout>
+         <div>
+            <section className="section section-grey">
+              <div className="row">
+                <div className="container text_1">
+                  <h1>{ this.d.accueil_titre_1 }</h1>
+                  <h2>{ this.d.accueil_titre_2 }</h2>
+                  <Link className="button large" to="/inscription">Je m'inscris</Link>
+                </div>
+                <img style={{}} className="opt_img illu-1" src={'illu-1.png'} alt="" srcSet="images/illu-1@2x.png 2x, images/illu-1@3x.png 3x" />
+              </div>
+            </section>
+            <div className="svg_container" aria-hidden="true" focusable="false">
+              <svg className="svg_1" viewBox="0 70 500 80" preserveAspectRatio="none">
+                <rect x={0} y={0} width={500} height={500} style={{stroke: 'none'}} />
+                <path d="M0,100 C150,0 350,250 500,100 L500,00 L0,0 Z" style={{stroke: 'none'}} />
+              </svg>
             </div>
-            <img style={{}} className="opt_img illu-1" src={'illu-1.png'} alt="" srcSet="images/illu-1@2x.png 2x, images/illu-1@3x.png 3x" />
-          </div>
-        </section>
-        <div className="svg_container" aria-hidden="true" focusable="false">
-          <svg className="svg_1" viewBox="0 70 500 80" preserveAspectRatio="none">
-            <rect x={0} y={0} width={500} height={500} style={{stroke: 'none'}} />
-            <path d="M0,100 C150,0 350,250 500,100 L500,00 L0,0 Z" style={{stroke: 'none'}} />
-          </svg>
-        </div>
-        <section>
-          <h2 className="section__title" style={{marginTop: '3rem'}}>Comment participer ?</h2>
-          <div className="container" style={{marginTop: '6rem'}}>
-            <div className="row numlist">
-              <div>
-                <span className="number">1</span>
-                <h3>Je m’inscris</h3>
-                <p>Je donne mon nom et mon email pour recevoir ensuite un questionnaire sur mon projet professionnel.</p>
-                <Link className="button fullwidth" to="/inscription">Je m'inscris</Link>
+            <section>
+              <h2 className="section__title" style={{marginTop: '3rem'}}>Comment participer ?</h2>
+              <div className="container" style={{marginTop: '6rem'}}>
+                <div className="row numlist">
+                  <div>
+                    <span className="number">1</span>
+                    <h3>Je m’inscris</h3>
+                    <p>Je donne mon nom et mon email pour recevoir ensuite un questionnaire sur mon projet professionnel.</p>
+                    <Link className="button fullwidth" to="/inscription">Je m'inscris</Link>
+                  </div>
+                  <div>
+                    <span className="number">2</span>
+                    <h3>Je remplis le questionnaire</h3>
+                    <p>Je donne le plus d'éléments possibles sur ma situation. Je peux me faire aider d’un proche ou d’un aidant pour le remplir.</p>
+                  </div>
+                  <div>
+                    <span className="number">3</span>
+                    <h3>Je suis contacté</h3>
+                    <p>Je reçois un email pour me dire quand commencera l’expérience pour moi. Elle peut démarrer plusieurs mois après l’envoi du questionnaire.</p>
+                  </div>
+                  <div>
+                    <span className="number">4</span>
+                    <h3>Je démarre l’expérience</h3>
+                    <p>L’équipe <abbr title={ abbr_andi } >ANDi</abbr> m’appuie dans la recherche d’un métier qui me plaît et me met en relation avec des entreprises qui sont prêtes à m'accueillir.</p>
+                  </div>
+                </div>
               </div>
-              <div>
-                <span className="number">2</span>
-                <h3>Je remplis le questionnaire</h3>
-                <p>Je donne le plus d'éléments possibles sur ma situation. Je peux me faire aider d’un proche ou d’un aidant pour le remplir.</p>
-              </div>
-              <div>
-                <span className="number">3</span>
-                <h3>Je suis contacté</h3>
-                <p>Je reçois un email pour me dire quand commencera l’expérience pour moi. Elle peut démarrer plusieurs mois après l’envoi du questionnaire.</p>
-              </div>
-              <div>
-                <span className="number">4</span>
-                <h3>Je démarre l’expérience</h3>
-                <p>L’équipe <abbr title={ abbr_andi } >ANDi</abbr> m’appuie dans la recherche d’un métier qui me plaît et me met en relation avec des entreprises qui sont prêtes à m'accueillir.</p>
-              </div>
+              <br />
+              <br />
+            </section>
+            <div className="svg_container" aria-hidden="true" focusable="false">
+              <svg className="svg_2" viewBox="0 70 500 60" preserveAspectRatio="none">
+                <rect x={0} y={0} width={500} height={500} style={{stroke: 'none'}} />
+                <path d="M0,100 C150,200 350,0 500,100 L500,00 L0,0 Z" style={{stroke: 'none'}} />
+              </svg>
             </div>
+            <section className="section section-grey" style={{marginTop: '2rem'}}>
+              <div className="row">
+                <div className="container text_2">
+                  <h2>Qui sommes nous ?</h2>
+                  <p> Nous sommes une petite équipe à la Caisse des Dépôts et nous portons un nouveau projet baptisé <strong><abbr title={ abbr_andi }>ANDi</abbr></strong>.</p>
+                  <p>Notre objectif est de permettre aux personnes en situation de handicap de réaliser des immersions professionnelles.</p>
+                  <p>Ce projet est en cours d’expérimentation. Il se construit actuellement avec des employeurs, des associations, des organismes d’Etat, et bien sur avec des personnes en situation de handicap qui cherchent un emploi.</p>
+                </div>
+                <img className="opt_img team-startup-illu" src={'team-startup-illu.png'} alt="" srcSet="images/team-startup-illu@2x.png 2x, images/team-startup-illu@3x.png 3x" />
+              </div>
+            </section>
           </div>
-          <br />
-          <br />
-        </section>
-        <div className="svg_container" aria-hidden="true" focusable="false">
-          <svg className="svg_2" viewBox="0 70 500 60" preserveAspectRatio="none">
-            <rect x={0} y={0} width={500} height={500} style={{stroke: 'none'}} />
-            <path d="M0,100 C150,200 350,0 500,100 L500,00 L0,0 Z" style={{stroke: 'none'}} />
-          </svg>
-        </div>
-        <section className="section section-grey" style={{marginTop: '2rem'}}>
-          <div className="row">
-            <div className="container text_2">
-              <h2>Qui sommes nous ?</h2>
-              <p> Nous sommes une petite équipe à la Caisse des Dépôts et nous portons un nouveau projet baptisé <strong><abbr title={ abbr_andi }>ANDi</abbr></strong>.</p>
-              <p>Notre objectif est de permettre aux personnes en situation de handicap de réaliser des immersions professionnelles.</p>
-              <p>Ce projet est en cours d’expérimentation. Il se construit actuellement avec des employeurs, des associations, des organismes d’Etat, et bien sur avec des personnes en situation de handicap qui cherchent un emploi.</p>
-            </div>
-            <img className="opt_img team-startup-illu" src={'team-startup-illu.png'} alt="" srcSet="images/team-startup-illu@2x.png 2x, images/team-startup-illu@3x.png 3x" />
-          </div>
-        </section>
-      </div>
-    </Layout>
-)
+        </Layout>
+    )
+    }
+}
 
 export default IndexPage


### PR DESCRIPTION
En réutilisant les outils déjà utilisés par notre solution (postgresql, evolutility), j'ai mis en place une interface graphql distincte (qui ne donne accès que aux ressources publiques de la table "assets") via evolutility.

Cet interface est ensuite utilisée par gatsby pour générer le site. Ça fonctionne nickel ;)
Pour le moment j'ai transféré que deux contenus (les titres principaux de la landing page), le reste se fera sur l'update frontend de @NolannBiron.